### PR TITLE
Fixed build on clang on macOS

### DIFF
--- a/src/include/LooseQuadtree-impl.h
+++ b/src/include/LooseQuadtree-impl.h
@@ -467,7 +467,7 @@ private:
 	using ObjectPointerContainer =
 		std::unordered_map<Object*, Object**,
 		std::hash<Object*>, std::equal_to<Object*>,
-		detail::BlocksAllocatorAdaptor<std::pair<const Object*, Object**>>>;
+		detail::BlocksAllocatorAdaptor<std::pair<Object *const, Object**>>>;
 	using QueryPoolContainer =
 		std::deque<typename LooseQuadtree<Number, Object, BoundingBoxExtractor>::Query::Impl>;
 


### PR DESCRIPTION
Because of that, the error happens on macOS:
```
In file included from scenes/level/lvl_quad_tree.cpp:3:
In file included from ./common_features/QuadTree/LooseQuadtree.h:116:
In file included from ./common_features/QuadTree/LooseQuadtree-impl.h:14:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/unordered_map:760:5: error: static_assert failed "Invalid allocator::value_type"
    static_assert((is_same<value_type, typename allocator_type::value_type>::value),
    ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./common_features/QuadTree/LooseQuadtree-impl.h:482:25: note: in instantiation of template class 'std::__1::unordered_map<PGE_Phys_Object *, PGE_Phys_Object **, std::__1::hash<PGE_Phys_Object *>, std::__1::equal_to<PGE_Phys_Object *>, loose_quadtree::detail::BlocksAllocatorAdaptor<std::__1::pair<const PGE_Phys_Object *, PGE_Phys_Object **> > >' requested here
        ObjectPointerContainer object_pointers_;
                               ^
./common_features/QuadTree/LooseQuadtree.h:109:7: note: in instantiation of member class 'loose_quadtree::LooseQuadtree<double, PGE_Phys_Object, QTreePGE_Phys_ObjectExtractor>::Impl' requested here
        Impl impl_;
             ^
scenes/level/lvl_quad_tree.cpp:20:16: note: in instantiation of template class 'loose_quadtree::LooseQuadtree<double, PGE_Phys_Object, QTreePGE_Phys_ObjectExtractor>' requested here
    IndexTreeQ tree;
```
https://travis-ci.org/WohlSoft/PGE-Project/jobs/218300920

The solution for this error is here: http://stackoverflow.com/questions/27336941/eigenaligned-allocator-fails-with-stdunordered-multimap

Then, it has successfully built:
https://travis-ci.org/WohlSoft/PGE-Project/jobs/218412207